### PR TITLE
Documentation requires odoc

### DIFF
--- a/argon2.opam
+++ b/argon2.opam
@@ -11,6 +11,7 @@ depends: [
   "ctypes" {>= "0.4.1"}
   "ctypes-foreign"
   "result"
+  "odoc" {with-doc}
 ]
 build: [
   ["dune" "subst"] {pinned}


### PR DESCRIPTION
Missing dependency in the opam file, as noted in https://github.com/Khady/ocaml-argon2/pull/3#discussion_r407182216