### PR TITLE
Link argon2 using pkg-config

### DIFF
--- a/argon2.opam
+++ b/argon2.opam
@@ -9,6 +9,7 @@ license: "MIT"
 depends: [
   "ocaml" {>= "4.02.3"}
   "dune" {>= "2.0"}
+  "dune-configurator" {>= "2.0"}
   "ctypes" {>= "0.4.1"}
   "ctypes-foreign"
   "result"

--- a/src/argon2.ml
+++ b/src/argon2.ml
@@ -1,9 +1,6 @@
 open Ctypes
 open Foreign
 
-let argon2_lib =
-  Dl.dlopen ~filename:"libargon2.so.1" ~flags:[ Dl.RTLD_NOW; Dl.RTLD_GLOBAL ]
-
 module Kind = struct
   type t = D | I | ID
 
@@ -18,7 +15,7 @@ module Kind = struct
   let t = view int ~read ~write
 
   let argon2_type2string =
-    foreign ~from:argon2_lib "argon2_type2string"
+    foreign "argon2_type2string"
       (t (* type *) @-> int (* uppercase *) @-> returning string)
 
   let show (case : [ `Upper | `Lower ]) t =
@@ -170,29 +167,29 @@ module ErrorCodes = struct
   let t = view int ~read ~write
 
   let argon2_error_message =
-    foreign ~from:argon2_lib "argon2_error_message" (t @-> returning string)
+    foreign "argon2_error_message" (t @-> returning string)
 
   let message error_code = argon2_error_message error_code
 end
 
 let hash_encoded fun_name =
-  foreign ~from:argon2_lib fun_name
-    ( uint32_t (* t_cost *) @-> uint32_t (* m_cost *)
+  foreign fun_name
+    (uint32_t (* t_cost *) @-> uint32_t (* m_cost *)
     @-> uint32_t (* parallelism *) @-> string
     (* pwd *) @-> size_t (* pwdlen *)
     @-> string (* salt *) @-> size_t
     (* saltlen *) @-> size_t (* hashlen *)
     @-> ptr char (* encoded *) @-> size_t (* encodedlen *)
-    @-> returning ErrorCodes.t )
+    @-> returning ErrorCodes.t)
 
 let hash_raw fun_name =
-  foreign ~from:argon2_lib fun_name
-    ( uint32_t (* t_cost *) @-> uint32_t (* m_cost *)
+  foreign fun_name
+    (uint32_t (* t_cost *) @-> uint32_t (* m_cost *)
     @-> uint32_t (* parallelism *) @-> string
     (* pwd *) @-> size_t (* pwdlen *)
     @-> string (* salt *) @-> size_t
     (* saltlen *) @-> ptr void (* hash *)
-    @-> size_t (* hashlen *) @-> returning ErrorCodes.t )
+    @-> size_t (* hashlen *) @-> returning ErrorCodes.t)
 
 let argon2i_hash_encoded = hash_encoded "argon2i_hash_encoded"
 
@@ -207,21 +204,21 @@ let argon2id_hash_encoded = hash_encoded "argon2id_hash_encoded"
 let argon2id_hash_raw = hash_raw "argon2id_hash_raw"
 
 let argon2_hash =
-  foreign ~from:argon2_lib "argon2_hash"
-    ( uint32_t (* t_cost *) @-> uint32_t (* m_cost *)
+  foreign "argon2_hash"
+    (uint32_t (* t_cost *) @-> uint32_t (* m_cost *)
     @-> uint32_t (* parallelism *) @-> string
     (* pwd *) @-> size_t (* pwdlen *)
     @-> string (* salt *) @-> size_t
     (* saltlen *) @-> ptr void (* hash *)
     @-> size_t (* hashlen *) @-> ptr char (* encoded *)
     @-> size_t (* encodedlen *) @-> Kind.t (* type *)
-    @-> Version.t (* version *) @-> returning ErrorCodes.t )
+    @-> Version.t (* version *) @-> returning ErrorCodes.t)
 
 let verify fun_name =
-  foreign ~from:argon2_lib fun_name
-    ( string (* encoded *) @-> string
+  foreign fun_name
+    (string (* encoded *) @-> string
     (* pwd *) @-> size_t (* pwdlen *)
-    @-> returning ErrorCodes.t )
+    @-> returning ErrorCodes.t)
 
 let argon2i_verify = verify "argon2i_verify"
 
@@ -230,17 +227,17 @@ let argon2d_verify = verify "argon2d_verify"
 let argon2id_verify = verify "argon2d_verify"
 
 let argon2_verify =
-  foreign ~from:argon2_lib "argon2_verify"
-    ( string (* encoded *) @-> string
+  foreign "argon2_verify"
+    (string (* encoded *) @-> string
     (* pwd *) @-> size_t (* pwdlen *)
-    @-> Kind.t (* type *) @-> returning ErrorCodes.t )
+    @-> Kind.t (* type *) @-> returning ErrorCodes.t)
 
 let argon2_encodedlen =
-  foreign ~from:argon2_lib "argon2_encodedlen"
-    ( uint32_t (* t_cost *) @-> uint32_t (* m_cost *)
+  foreign "argon2_encodedlen"
+    (uint32_t (* t_cost *) @-> uint32_t (* m_cost *)
     @-> uint32_t (* parallelism *) @-> uint32_t (* saltlen *)
     @-> uint32_t (* hashlen *) @-> Kind.t
-    (* type *) @-> returning size_t )
+    (* type *) @-> returning size_t)
 
 let hash_encoded hash_fun ~t_cost ~m_cost ~parallelism ~pwd ~salt ~hash_len
     ~encoded_len =

--- a/src/config/discover.ml
+++ b/src/config/discover.ml
@@ -1,0 +1,28 @@
+module C = Configurator.V1
+
+(* Backported from OCaml 4.10.0 *)
+let concat_map f l =
+  let rec aux f acc = function
+    | [] -> List.rev acc
+    | x :: l ->
+        let xs = f x in
+        aux f (List.rev_append xs acc) l
+  in
+  aux f [] l
+
+let () =
+  C.main ~name:"argon2" (fun c ->
+      let default : C.Pkg_config.package_conf =
+        { libs = [ "-largon2" ]; cflags = [] }
+      in
+      let conf =
+        match C.Pkg_config.get c with
+        | None -> default
+        | Some pc -> (
+            match C.Pkg_config.query pc ~package:"libargon2" with
+            | None -> default
+            | Some deps -> deps)
+      in
+
+      concat_map (fun flag -> [ "-cclib"; flag ]) conf.libs
+      |> C.Flags.write_sexp "flags.sexp")

--- a/src/config/dune
+++ b/src/config/dune
@@ -1,0 +1,3 @@
+(executable
+ (name discover)
+ (libraries dune-configurator))

--- a/src/dune
+++ b/src/dune
@@ -2,4 +2,12 @@
  (name argon2)
  (public_name argon2)
  (libraries result ctypes.foreign ctypes)
+ (flags
+  :standard
+  (:include flags.sexp))
  (synopsis "OCaml bindings to argon2"))
+
+(rule
+ (targets flags.sexp)
+ (action
+  (run ./config/discover.exe)))


### PR DESCRIPTION
With this change argon2 will be linked using pkg-config, fixing #6. [Configurator docs](https://dune.readthedocs.io/en/stable/dune-libs.html?highlight=pkg_config#configurator), [example from docs](https://dune.readthedocs.io/en/stable/quick-start.html?highlight=c_library_flags#defining-a-library-with-c-stubs-using-pkg-config). I did it slightly differently to the Configurator pkg-config example and used `(flags ...)` instead of `(c_library_flags ...)` stanza since these bindings are built directly with Ctypes.Foreign and libffi instead of C stubs.